### PR TITLE
Remove code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,0 @@
-# Code of Conduct
-
-The code of conduct for this project can be found at https://swift.org/code-of-conduct.
-
-<!-- Copyright (c) 2014 - 2022 Apple Inc. and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
Remove this repo-local copy, to follow the swiftlang org-wide policy instead of individual repo files. Having this file present means the repo is opt-ing out of the org wide policy, which is not the case.


