### PR TITLE
Add isolation() macro to list of allowed default parameter values

### DIFF
--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -1521,13 +1521,15 @@ A macro-expansion expression omits the parentheses after the macro's name
 if the macro doesn't take any arguments.
 
 A macro-expansion expression can't appear as the default value for a parameter,
-except the [`file()`][] and [`line()`][] macros from the Swift standard library.
-When used as the default value of a function or method parameter,
-these macros are evaluated using the source code location of the call site,
-not the location where they appear in a function definition.
+except the [`file()`][],  [`line()`][] and [`isolation()`][] macros from the Swift standard library.
 
 [`file()`]: https://developer.apple.com/documentation/swift/file()
 [`line()`]: https://developer.apple.com/documentation/swift/line()
+[`isolation()`]: https://developer.apple.com/documentation/swift/isolation()
+
+When used as the default value of a function or method parameter,
+these macros are evaluated using the source code location of the call site,
+not the location where they appear in a function definition.
 
 You use macro expressions to call freestanding macros.
 To call an attached macro,

--- a/TSPL.docc/RevisionHistory/RevisionHistory.md
+++ b/TSPL.docc/RevisionHistory/RevisionHistory.md
@@ -2,6 +2,10 @@
 
 Review the recent changes to this book.
 
+**XXX release date XXX**
+
+- Minor corrections throughout.
+
 **2024-06-10**
 
 - Updated for Swift 6.


### PR DESCRIPTION
<!-- What's in this pull request? -->
The isolation() macro is a new entry in the special case macros allowed to be used for default argument values.
This PR updates that section to include it with link.

<!-- Link to the issue that this pull request fixes, if applicable. -->
Fixes: rdar://133387175
