### PR TITLE
Alphabetize keywords in `LexicalStructure.md`

### DIFF
--- a/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -263,8 +263,8 @@ so they must be escaped with backticks in that context.
   `nonisolated`,
   `open`,
   `operator`,
-  `private`,
   `precedencegroup`,
+  `private`,
   `protocol`,
   `public`,
   `rethrows`,
@@ -294,8 +294,8 @@ so they must be escaped with backticks in that context.
   `in`,
   `repeat`,
   `return`,
-  `throw`,
   `switch`,
+  `throw`,
   `where`,
   and `while`.
 - Keywords used in expressions and types:


### PR DESCRIPTION
While skimming the keyword reference, I noticed that 2 keywords were not listed in alphabetical order.
I know this is like, the most minor thing in the world, but it seems like everything else is properly ordered, so I figured... why not?

With this PR, all the keyword lists on this page would be in alphabetical order.

----

After doing a little more digging, there's actually an open issue for this! #242,
although it deals with more than just fixing the order of these two.