### PR TITLE
Add 'async' to the List of Reserved Keyword

### DIFF
--- a/TSPL.docc/ReferenceManual/LexicalStructure.md
+++ b/TSPL.docc/ReferenceManual/LexicalStructure.md
@@ -373,6 +373,7 @@ so they must be escaped with backticks in that context.
 
 - Keywords reserved in particular contexts:
   `associativity`,
+  `async`,
   `convenience`,
   `didSet`,
   `dynamic`,


### PR DESCRIPTION
One of the projects I work on maintains a list of keywords (for escaping purposes), and while looking through it, I noticed that a big one (`async`) was missing from the reference.

So, I thought I'd open a quick PR to add it!
But after looking through the issues and finding #242, it turns out there's actually a few missing...
Figured I'd still open this, but if you'd prefer to close it and wait until a more comprehensive PR can fix _all_ the missing keywords, it'd be no skin off my back! : v)

----

As for the placement, looking through the grammar rules, it looks like `async` is only reserved in certain contexts.
For instance, it's valid to use `async` as an identifier.