### PR TITLE
Specify code listings are Swift

### DIFF
--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -630,7 +630,7 @@ For a task group that returns a result,
 you add code that accumulates its result
 inside the closure you pass to `withTaskGroup(of:returning:body:)`.
 
-```
+```swift
 let photos = await withTaskGroup(of: Data.self) { group in
     let photoNames = await listPhotos(inGallery: "Summer Vacation")
     for name in photoNames {
@@ -708,7 +708,7 @@ like closing network connections and deleting temporary files.
 [`Task.checkCancellation()`]: https://developer.apple.com/documentation/swift/task/3814826-checkcancellation
 [`Task.isCancelled` type]: https://developer.apple.com/documentation/swift/task/iscancelled-swift.type.property
 
-```
+```swift
 let photos = await withTaskGroup(of: Optional<Data>.self) { group in
     let photoNames = await listPhotos(inGallery: "Summer Vacation")
     for name in photoNames {

--- a/TSPL.docc/LanguageGuide/Macros.md
+++ b/TSPL.docc/LanguageGuide/Macros.md
@@ -240,7 +240,7 @@ to add conformance to the `OptionSet` protocol.
 For a freestanding macro,
 you write the `@freestanding` attribute to specify its role:
 
-```
+```swift
 @freestanding(expression)
 public macro line<T: ExpressibleByIntegerLiteral>() -> T =
         /* ... location of the macro implementation... */
@@ -317,7 +317,7 @@ Specifically, Swift expands macros in the following way:
 
 To go through the specific steps, consider the following:
 
-```
+```swift
 let magicNumber = #fourCharacterCode("ABCD")
 ```
 
@@ -413,7 +413,7 @@ That produces a final AST that can be compiled as usual:
 
 This AST corresponds to Swift code like this:
 
-```
+```swift
 let magicNumber = 1145258561 as UInt32
 ```
 

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -1528,7 +1528,7 @@ However, when a default value is a larger expression
 that contains a macro in addition to other code,
 those macros are evaluated where they appear in the function definition.
 
-```
+```swift
 func f(a: Int = #line, b: Int = (#line), c: Int = 100 + #line) {
     print(a, b, c)
 }


### PR DESCRIPTION
Because the `Info.plist` file specifies Swift as the default language via the `CDDefaultCodeListingLanguage` key, code listings with an unspecified language should still render correctly.  However, it's still good to be explicit and makes the markdown files more usable by other toolchains.

Used the following script to find code listings that were missing an explicit language, and to verify that none remain after this change:

```
echo "Not specified as Swift"
cmark --to xml TSPL.docc/*/*.md |
xpath -q -n -e '//code_block[not(@info="swift")]'

echo "Languages used"
cmark --to xml TSPL.docc/*/*.md |
xpath -q -n -e '//code_block/@info' |
sort -u
```