### PR TITLE
Add a redirect at the top level

### DIFF
--- a/bin/publish-book
+++ b/bin/publish-book
@@ -52,3 +52,6 @@ cp -r bin/redirects/LanguageGuide "$output"
 cp -r bin/redirects/ReferenceManual "$output"
 cp -r bin/redirects/RevisionHistory "$output"
 cp -r bin/redirects/index.html "$output"
+
+# Add a redirect page from swift.org/swift-book/documentation/.
+cp -r bin/redirects/documentation/index.html "$output/documentation/"

--- a/bin/redirects/documentation/index.html
+++ b/bin/redirects/documentation/index.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+    <title>The Swift Programming Language: Redirect</title>
+    <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/">
+<head>
+<body>
+<div>
+This content has moved; redirecting to the
+<a href="https://docs.swift.org/swift-book/documentation/the-swift-programming-language/" id="redirect">new location</a>.
+<noscript>
+<aside>
+This page requires JavaScript.
+Please turn on JavaScript and refresh the page.
+</aside>
+</noscript>
+</div>
+<script>
+const baseURL = "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/";
+
+var newURL = baseURL;
+
+document.getElementById("redirect").setAttribute("href", newURL);
+window.location = newURL;
+</script>
+</body>
+</html>

--- a/bin/redirects/index.html
+++ b/bin/redirects/index.html
@@ -2,7 +2,7 @@
 <head>
     <title>The Swift Programming Language: Redirect</title>
     <meta http-equiv="refresh" content="10; url=https://docs.swift.org/swift-book/documentation/the-swift-programming-language/compatibility">
-<head>
+</head>
 <body>
 <div>
 This content has moved; redirecting to the


### PR DESCRIPTION
Without this redirect, the server generates a directory listing for <https://docs.swift.org/swift-book/documentation/> and you have to click through to the actual content.

This page uses a reduced version of the existing redirect page, with the majority of the JavaScript removed.  Because we never hosted any pre-DocC content at this URL, there's no reason to inspect the fragment and do a more specific redirect.  There aren't any old URLs that point here for us to avoid breaking.

Fixes: rdar://137038334