### PR TITLE
Fix type inference example in "Creating an Empty Array"

### DIFF
--- a/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -74,7 +74,7 @@ You can create an empty array of a certain type
 using initializer syntax:
 
 ```swift
-var someInts: [Int] = []
+var someInts = [Int]()
 print("someInts is of type [Int] with \(someInts.count) items.")
 // Prints "someInts is of type [Int] with 0 items."
 ```

--- a/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -70,9 +70,7 @@ and is used throughout this guide when referring to the type of an array.
 
 ### Creating an Empty Array
 
-You can create an empty array in Swift using two approaches,
-as shown in the following examples.
-
+You can create an empty array in Swift using two approaches.
 If the context already provides type information,
 such as a function argument or an already typed variable or constant,
 you can use an empty array literal,

--- a/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -70,8 +70,34 @@ and is used throughout this guide when referring to the type of an array.
 
 ### Creating an Empty Array
 
-You can create an empty array of a certain type
-using initializer syntax:
+You can create an empty array in Swift using one of two approaches:
+
+If the context already provides type information,
+such as a function argument or an already typed variable or constant,
+you can create an empty array with an *empty array literal*,
+which is written as `[]`
+(an empty pair of square brackets):
+
+```swift
+var someInts: [Int] = []
+print("someInts is of type [Int] with \(someInts.count) items.")
+// Prints "someInts is of type [Int] with 0 items."
+```
+
+<!--
+  - test: `arraysEmpty`
+
+  ```swifttest
+  -> var someInts: [Int] = []
+  -> print("someInts is of type [Int] with \(someInts.count) items.")
+  <- someInts is of type [Int] with 0 items.
+  ```
+-->
+
+Alternatively, you can create an empty array of a certain type 
+using *initializer syntax*, 
+which is done by writing the type in square brackets 
+followed by parentheses (`[Element]()`):
 
 ```swift
 var someInts = [Int]()
@@ -89,14 +115,13 @@ print("someInts is of type [Int] with \(someInts.count) items.")
   ```
 -->
 
-Note that the type of the `someInts` variable is inferred to be `[Int]`
-from the type of the initializer.
+Both approaches produce the same result. 
+However, the empty array literal (`[]`) is the preferred way to 
+initialize an empty array because it is more concise and aligns with 
+the style guidelines used throughout this guide.
 
-Alternatively, if the context already provides type information,
-such as a function argument or an already typed variable or constant,
-you can create an empty array with an empty array literal,
-which is written as `[]`
-(an empty pair of square brackets):
+In both cases, you can use the empty array literal (`[]`) to 
+reassign an empty array to an existing variable:
 
 ```swift
 someInts.append(3)

--- a/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -94,9 +94,9 @@ print("someInts is of type [Int] with \(someInts.count) items.")
   ```
 -->
 
-Alternatively, you can create an empty array of a certain type 
-using *initializer syntax*, 
-which is done by writing the type in square brackets 
+Alternatively, you can create an empty array of a certain type
+using *initializer syntax*,
+which is done by writing the type in square brackets
 followed by parentheses (`[Element]()`):
 
 ```swift
@@ -115,12 +115,12 @@ print("someInts is of type [Int] with \(someInts.count) items.")
   ```
 -->
 
-Both approaches produce the same result. 
-However, the empty array literal (`[]`) is the preferred way to 
-initialize an empty array because it is more concise and aligns with 
+Both approaches produce the same result.
+However, the empty array literal (`[]`) is the preferred way to
+initialize an empty array because it is more concise and aligns with
 the style guidelines used throughout this guide.
 
-In both cases, you can use the empty array literal (`[]`) to 
+In both cases, you can use the empty array literal (`[]`) to
 reassign an empty array to an existing variable:
 
 ```swift

--- a/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -70,11 +70,12 @@ and is used throughout this guide when referring to the type of an array.
 
 ### Creating an Empty Array
 
-You can create an empty array in Swift using one of two approaches:
+You can create an empty array in Swift using two approaches,
+as shown in the following examples.
 
 If the context already provides type information,
 such as a function argument or an already typed variable or constant,
-you can create an empty array with an *empty array literal*,
+you can use an empty array literal,
 which is written as `[]`
 (an empty pair of square brackets):
 
@@ -95,9 +96,10 @@ print("someInts is of type [Int] with \(someInts.count) items.")
 -->
 
 Alternatively, you can create an empty array of a certain type
-using *initializer syntax*,
-which is done by writing the type in square brackets
-followed by parentheses (`[Element]()`):
+using explicit initializer syntax,
+by writing the element type in square brackets
+followed by parentheses ---
+for example, `[Int]()` in the following:
 
 ```swift
 var someInts = [Int]()
@@ -106,9 +108,8 @@ print("someInts is of type [Int] with \(someInts.count) items.")
 ```
 
 Both approaches produce the same result.
-However, the empty array literal (`[]`) is the preferred way to
-initialize an empty array because it is more concise and aligns with
-the style guidelines used throughout this guide.
+However,
+an empty array literal is shorter and usually easier to read.
 
 In both cases, you can use the empty array literal (`[]`) to
 reassign an empty array to an existing variable:

--- a/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -83,7 +83,7 @@ print("someInts is of type [Int] with \(someInts.count) items.")
   - test: `arraysEmpty`
 
   ```swifttest
-  -> var someInts: [Int] = []
+  -> var someInts = [Int]()
   -> print("someInts is of type [Int] with \(someInts.count) items.")
   <- someInts is of type [Int] with 0 items.
   ```

--- a/TSPL.docc/LanguageGuide/CollectionTypes.md
+++ b/TSPL.docc/LanguageGuide/CollectionTypes.md
@@ -105,16 +105,6 @@ print("someInts is of type [Int] with \(someInts.count) items.")
 // Prints "someInts is of type [Int] with 0 items."
 ```
 
-<!--
-  - test: `arraysEmpty`
-
-  ```swifttest
-  -> var someInts = [Int]()
-  -> print("someInts is of type [Int] with \(someInts.count) items.")
-  <- someInts is of type [Int] with 0 items.
-  ```
--->
-
 Both approaches produce the same result.
 However, the empty array literal (`[]`) is the preferred way to
 initialize an empty array because it is more concise and aligns with


### PR DESCRIPTION
<!-- If this pull request incorporates language changes from a Swift Evolution proposal, add the SE number in square brackets at the end of the PR title. -->

<!-- What's in this pull request? -->
This pull request resolves an inconsistency in the "**Creating an Empty Array**" section of the Swift Language Guide under "**Collection Types**."

### Changes:
- Updated the example code by replacing `var someInts: [Int] = []` with `var someInts = [Int]()` to accurately demonstrate type inference, aligning with the accompanying explanatory text.

### Rationale:
The previous example did not demonstrate type inference, as the type `[Int]` was explicitly declared using `: [Int]`. However, the accompanying text states:  
> "Note that the type of the `someInts` variable is **inferred** to be `[Int]` from the type of the initializer."  

This was misleading because type inference did not occur in the provided example. The updated example clarifies the explanation and ensures consistency across the guide, aligning with similar sections such as "**Creating and Initializing an Empty Set**."

<!-- Link to the issue that this pull request fixes, if applicable. -->