### PR TITLE
Fix terminology for string literal in example explanation

### DIFF
--- a/TSPL.docc/LanguageGuide/Initialization.md
+++ b/TSPL.docc/LanguageGuide/Initialization.md
@@ -2450,7 +2450,7 @@ class UntitledDocument: Document {
 In this case, if the `init(name:)` initializer of the superclass
 were ever called with an empty string as the name,
 the forced unwrapping operation would result in a runtime error.
-However, because it's called with a string constant,
+However, because it's called with a string literal,
 you can see that the initializer won't fail,
 so no runtime error can occur in this case.
 


### PR DESCRIPTION
<!-- If this pull request incorporates language changes from a Swift Evolution proposal, add the SE number in square brackets at the end of the PR title. -->

<!-- What's in this pull request? -->
This pull request addresses a terminology issue in the "[Overriding a Failable Initializer](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/initialization/#Overriding-a-Failable-Initializer)" section of the Swift Language Guide. The explanation incorrectly referred to `"[Untitled]"` from the example as a "string constant," which is not accurate. In Swift, `"[Untitled]"` is a string literal, not a constant.
```swift
super.init(name: "[Untitled]")!
```
<!-- Link to the issue that this pull request fixes, if applicable. -->