### PR TITLE
Improve concurrency example of transient invalid states

### DIFF
--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -1108,7 +1108,7 @@ the code below converts measured temperatures from Fahrenheit to Celsius:
 extension TemperatureLogger {
     func convertFahrenheitToCelsius() {
         for i in measurements.indices {
-            measurements[i] =  (measurements[i] - 32) * 5 / 9
+            measurements[i] = (measurements[i] - 32) * 5 / 9
         }
     }
 }

--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -1107,8 +1107,8 @@ the code below converts measured temperatures from Fahrenheit to Celsius:
 ```swift
 extension TemperatureLogger {
     func convertFahrenheitToCelsius() {
-        measurements = measurements.map { measurement in
-            (measurement - 32) * 5 / 9
+        for i in measurements.indices {
+            measurements[i] =  (measurements[i] - 32) * 5 / 9
         }
     }
 }


### PR DESCRIPTION
The old example actually makes an atomic update to the array of temperatures because it uses `map`.  Updating them in a `for` loop makes it more obvious that some temperatures will be Fahrenheit and some Celsius when the program's in the middle of the loop.

Fixes: rdar://139633262
