### PR TITLE
Fix typo for nono-ptional with non-optional at Style.md

### DIFF
--- a/Style.md
+++ b/Style.md
@@ -164,7 +164,7 @@ See entry for *function*.
 
 ## non-optional
 
-Hyphenated to avoid the misreading as nono-ptional.
+Hyphenated to avoid the misreading as non-optional.
 Normal rules for hyphenation from Apple Style Guide would omit the hyphen.
 
 See also commit 51c4fbc135a5e82343a0f5d9121f8a060b59f1a3 and <rdar://problem/44881846>.


### PR DESCRIPTION
Fix typo for `nono-ptional` with `non-optional` at Style.md.