### PR TITLE
Use the DocC from Xcode

### DIFF
--- a/bin/publish-book
+++ b/bin/publish-book
@@ -9,17 +9,6 @@
 # See https://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 # Prepares a version of the book suitable for publication on swift.org.
-#
-# To use top-of-tree DocC, clone the following repositories:
-#
-#     https://github.com/apple/swift-docc
-#     https://github.com/apple/swift-docc-render
-#
-# Then set environment variables to paths in their working directories,
-# like the following, before running this script:
-#
-#     PATH=~/git/DocC/.build/arm64-apple-macosx/debug:$PATH
-#     DOCC_HTML_DIR=~/git/DocC-Renderer/dist/
 
 set -eux
 
@@ -36,7 +25,7 @@ cd "$(git rev-parse --show-toplevel)"
 # The published version of the book gets the swift.org header.
 cp -n TSPL.docc/header-publish.html TSPL.docc/header.html
 
-docc convert \
+xcrun docc convert \
     --experimental-enable-custom-templates \
     --hosting-base-path swift-book \
     --output-path "$output" \

--- a/bin/update-book-preview
+++ b/bin/update-book-preview
@@ -14,19 +14,8 @@
 # This script should be run by someone with commit access to the 'gh-pages' branch
 # at a regular frequency so that the documentation content on the GitHub Pages site
 # is up-to-date with the content in this repo.
-#
-# To use top-of-tree DocC, clone the following repositories:
-#
-#     https://github.com/apple/swift-docc
-#     https://github.com/apple/swift-docc-render
-#
-# Then set environment variables to paths in their working directories,
-# like the following, before running this script:
-#
-#     PATH=~/git/DocC/.build/arm64-apple-macosx/debug:$PATH
-#     DOCC_HTML_DIR=~/git/DocC-Renderer/dist/
 
-set -eu
+set -eux
 
 REMOTE=${1:-origin}
 CURRENT_COMMIT_HASH="$(git rev-parse --short HEAD)"
@@ -46,7 +35,7 @@ export DOCC_JSON_PRETTYPRINT="YES"
 cp -n TSPL.docc/header-staging.html TSPL.docc/header.html
 
 # Build documentation, writing output in the gh-pages/docs subdirectory.
-docc convert \
+xcrun docc convert \
     --experimental-enable-custom-templates \
     --hosting-base-path swift-book \
     --output-path "./gh-pages/docs" \


### PR DESCRIPTION
TSPL hasn't needed DocC to build built from source for a while now.  Relying on Xcode for `docc` simplifies and speeds up the build process.