### PR TITLE
Fix incorrect throws syntax in error handling documentation

### DIFF
--- a/TSPL.docc/LanguageGuide/ErrorHandling.md
+++ b/TSPL.docc/LanguageGuide/ErrorHandling.md
@@ -802,7 +802,7 @@ You can call a function that uses typed throws
 from within a regular throwing function:
 
 ```swift
-func someThrowingFunction() -> throws {
+func someThrowingFunction() throws {
     let ratings = [1, 2, 3, 2, 2, 1]
     try summarize(ratings)
 }
@@ -814,7 +814,7 @@ You could also write the error type explicitly as `throws(any Error)`;
 the code below is equivalent to the code above:
 
 ```swift
-func someThrowingFunction() -> throws(any Error) {
+func someThrowingFunction() throws(any Error) {
     let ratings = [1, 2, 3, 2, 2, 1]
     try summarize(ratings)
 }


### PR DESCRIPTION
<!-- If this pull request incorporates language changes from a Swift Evolution proposal, add the SE number in square brackets at the end of the PR title. -->
The Swift documentation contains an incorrect function declaration in the Error Handling section:
The throws modifier should be before { and not after ->.
<!-- What's in this pull request? -->
Current (incorrect) code:
```
func someThrowingFunction() -> throws 
func someThrowingFunction() -> throws(any Error)
```
Fix:
```
func someThrowingFunction() throws 
func someThrowingFunction() throws(any Error)
```
<!-- Link to the issue that this pull request fixes, if applicable. -->
Documentation Link:
https://docs.swift.org/swift-book/documentation/the-swift-programming-language/errorhandling#Specifying-the-Error-Type
Issue Link:
https://github.com/swiftlang/swift-book/issues/360

Similar Pull-Request:
https://github.com/swiftlang/swift-book/pull/358
