### PR TITLE
Show if-case and for-case in the guide

### DIFF
--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -1484,9 +1484,9 @@ The `for`-`in` loop above iterates over an array of tuples,
 binding the first and second elements of the tuples
 to the `x` and `y` constants.
 The statements inside the loop can use those constants,
-like the `if` statement that checks whether the point lies on the x-axis.
+such as the `if` statement that checks whether the point lies on the x-axis.
 A more concise way to write this code
-is to combine the value bindings and condition,
+is to combine the value bindings and condition
 using a `for`-`case`-`in` loop.
 The code below has the same behavior as the `for`-`in` loop above:
 
@@ -2073,8 +2073,6 @@ It lets you write the code that's typically executed
 without wrapping it in an `else` block,
 and it lets you keep the code that handles a violated requirement
 next to the requirement.
-
-<!-- XXX show guard-case syntax for completeness? -->
 
 ## Deferred Actions
 

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -880,8 +880,6 @@ on the right-hand side of an assignment,
 as shown in the examples above,
 you can also use them as the value that a function or closure returns.
 
-<!-- XXX forward reference to if-case syntax? -->
-
 ### Switch
 
 A `switch` statement considers a value
@@ -1298,8 +1296,6 @@ Because `anotherPoint` is always a tuple of two values,
 this case matches all possible remaining values,
 and a `default` case isn't needed to make the `switch` statement exhaustive.
 
-<!-- XXX cross reference if-case syntax from here -->
-
 #### Where
 
 A `switch` case can use a `where` clause to check for additional conditions.
@@ -1443,6 +1439,35 @@ Both patterns include a binding for `distance`
 and `distance` is an integer in both patterns ---
 which means that the code in the body of the `case`
 can always access a value for `distance`.
+
+## Patterns
+
+XXX OUTLINE:
+
+- Each switch case takes a *pattern*
+  that describes what values that case handles
+- You can also use patterns with if and for
+- The for-case syntax is useful when you want to iterate
+  over only certain elements in a collection
+- Because patterns can bind values,
+  they're also useful for working with enumerations that have associated values
+  XREF <doc:Enumerations#Associated-Values>
+
+```swift
+let somePoint = (12, 100)
+if case (let x, 100) = somePoint {
+    print("Found a point with x of \(x)")
+}
+
+let points = [(10, 0), (30, 100), (-20, 0)]
+for case (let x, let y) in points {
+    guard y == 0 else { continue }
+    print("Found a point on the x-axis at \(x)")
+}
+for case (let x, let y) in points where y == 0  {
+    print("Found a point on the x-axis at \(x)")
+}
+```
 
 ## Control Transfer Statements
 

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -880,6 +880,8 @@ on the right-hand side of an assignment,
 as shown in the examples above,
 you can also use them as the value that a function or closure returns.
 
+<!-- XXX forward reference to if-case syntax? -->
+
 ### Switch
 
 A `switch` statement considers a value
@@ -1295,6 +1297,8 @@ declares a tuple of two placeholder constants that can match any value.
 Because `anotherPoint` is always a tuple of two values,
 this case matches all possible remaining values,
 and a `default` case isn't needed to make the `switch` statement exhaustive.
+
+<!-- XXX cross reference if-case syntax from here -->
 
 #### Where
 

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -1442,32 +1442,75 @@ can always access a value for `distance`.
 
 ## Patterns
 
-XXX OUTLINE:
-
-- Each switch case takes a *pattern*
-  that describes what values that case handles
-- You can also use patterns with if and for
-- The for-case syntax is useful when you want to iterate
-  over only certain elements in a collection
-- Because patterns can bind values,
-  they're also useful for working with enumerations that have associated values
-  XREF <doc:Enumerations#Associated-Values>
+In the previous examples, each switch case includes a pattern
+that indicates what values match that case.
+You can also use a pattern as the condition for an `if` statement.
+Here's what that looks like:
 
 ```swift
 let somePoint = (12, 100)
 if case (let x, 100) = somePoint {
-    print("Found a point with x of \(x)")
+    print("Found a point on the y=100 line, at \(x)")
 }
-
-let points = [(10, 0), (30, 100), (-20, 0)]
-for case (let x, let y) in points {
-    guard y == 0 else { continue }
-    print("Found a point on the x-axis at \(x)")
-}
-for case (let x, let y) in points where y == 0  {
-    print("Found a point on the x-axis at \(x)")
-}
+// Prints "Found a point on the y=100 line, at 12"
 ```
+
+In this code,
+the condition for the `if` statement starts with `case`,
+indicating that the condition is a pattern instead of a Boolean value.
+If the pattern matches,
+the condition for the `if` is considered to be true,
+and the code in the body of the `if` statement runs.
+The patterns you can write after `if case`
+are the same as the patterns you can write in a switch case.
+
+You can also use a pattern in a `for`-`in` loop,
+to give names to parts of the value using a value binding:
+
+```swift
+let points = [(10, 0), (30, 100), (-20, 0)]
+
+for case let (x, y) in points {
+    if y == 0 {
+        print("Found a point on the x-axis at \(x)")
+    }
+}
+// Prints "Found a point on the x-axis at 10"
+// Prints "Found a point on the x-axis at -20"
+```
+
+The `for`-`in` loop above iterates over an array of tuples,
+binding the first and second elements of the tuples
+to the `x` and `y` constants.
+The statements inside the loop can use those constants,
+like the `if` statement that checks whether the point lies on the x-axis.
+
+A `for`-`case`-`in` loop can also include a `where` clause,
+to check for an additional condition.
+The statements inside the loop run
+only when `where` clause matches the current element.
+For example,
+the `for`-`case`-`in` loop below is the same as the `for`-`in` loop above.
+
+```swift
+for case let (x, y) in points where y == 0  {
+    print("Found a point on the x-axis at \(x)")
+}
+// Prints "Found a point on the x-axis at 10"
+// Prints "Found a point on the x-axis at -20"
+```
+
+In this code,
+the condition is integrated into the `for`-`case`-`in` loop as part of the pattern.
+The statements in the `for`-`case`-`in` loop run only for points on the x-axis.
+This code produces the same result as the `for`-`in` loop above,
+but is a more compact way to iterate
+over only certain elements in a collection.
+
+Because patterns can bind values,
+`if`-`case` statements and `for`-`case`-`in` loops
+are useful for working with enumerations that have associated values,
+as described in <doc:Enumerations#Associated-Values>.
 
 ## Control Transfer Statements
 
@@ -2011,6 +2054,8 @@ It lets you write the code that's typically executed
 without wrapping it in an `else` block,
 and it lets you keep the code that handles a violated requirement
 next to the requirement.
+
+<!-- XXX show guard-case syntax for completeness? -->
 
 ## Deferred Actions
 

--- a/TSPL.docc/LanguageGuide/ControlFlow.md
+++ b/TSPL.docc/LanguageGuide/ControlFlow.md
@@ -1459,18 +1459,19 @@ In this code,
 the condition for the `if` statement starts with `case`,
 indicating that the condition is a pattern instead of a Boolean value.
 If the pattern matches,
-the condition for the `if` is considered to be true,
-and the code in the body of the `if` statement runs.
+then the condition for the `if` is considered to be true,
+and so the code in the body of the `if` statement runs.
 The patterns you can write after `if case`
 are the same as the patterns you can write in a switch case.
 
-You can also use a pattern in a `for`-`in` loop,
-to give names to parts of the value using a value binding:
+In a `for`-`in` loop,
+you can give names to parts of the value using a value binding pattern,
+even without writing `case` in your code:
 
 ```swift
-let points = [(10, 0), (30, 100), (-20, 0)]
+let points = [(10, 0), (30, -30), (-20, 0)]
 
-for case let (x, y) in points {
+for (x, y) in points {
     if y == 0 {
         print("Found a point on the x-axis at \(x)")
     }
@@ -1484,16 +1485,13 @@ binding the first and second elements of the tuples
 to the `x` and `y` constants.
 The statements inside the loop can use those constants,
 like the `if` statement that checks whether the point lies on the x-axis.
-
-A `for`-`case`-`in` loop can also include a `where` clause,
-to check for an additional condition.
-The statements inside the loop run
-only when `where` clause matches the current element.
-For example,
-the `for`-`case`-`in` loop below is the same as the `for`-`in` loop above.
+A more concise way to write this code
+is to combine the value bindings and condition,
+using a `for`-`case`-`in` loop.
+The code below has the same behavior as the `for`-`in` loop above:
 
 ```swift
-for case let (x, y) in points where y == 0  {
+for case (let x, 0) in points {
     print("Found a point on the x-axis at \(x)")
 }
 // Prints "Found a point on the x-axis at 10"
@@ -1501,11 +1499,32 @@ for case let (x, y) in points where y == 0  {
 ```
 
 In this code,
-the condition is integrated into the `for`-`case`-`in` loop as part of the pattern.
+the condition is integrated into the `for`-`case`-`in` loop
+as part of the pattern.
 The statements in the `for`-`case`-`in` loop run only for points on the x-axis.
 This code produces the same result as the `for`-`in` loop above,
 but is a more compact way to iterate
 over only certain elements in a collection.
+
+A `for`-`case`-`in` loop can also include a `where` clause,
+to check for an additional condition.
+The statements inside the loop run
+only when `where` clause matches the current element.
+For example:
+
+```swift
+for case let (x, y) in points where x == y || x == -y  {
+    print("Found (\(x), \(y)) along a line through the origin")
+}
+// Prints "Found (30, -30) along a line through the origin"
+```
+
+This code binds the first and second elements of the tuple
+to `x` and `y` as constants,
+and then checks their values in the `where` clause.
+If the `where` clause is `true`,
+then the code in the body of the `for` loop runs;
+otherwise, iteration continues with the next element.
 
 Because patterns can bind values,
 `if`-`case` statements and `for`-`case`-`in` loops

--- a/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/TSPL.docc/LanguageGuide/Enumerations.md
@@ -479,6 +479,31 @@ case let .qrCode(productCode):
   ```
 -->
 
+When you're matching just one case of an enumeration,
+you can use the shorter `if case` syntax
+instead of writing a full switch statement.
+For example:
+
+```swift
+if case .qrCode(let productCode) = productBarcode {
+    print("QR code: \(productCode).")
+}
+```
+
+In this code,
+the condition for the `if` statement starts with `case`,
+indicating that the condition is a pattern instead of a Boolean value.
+If the pattern matches,
+the condition for the `if` is considered to be true;
+otherwise it's false.
+Just like in the switch statement earlier,
+the `productBarcode` variable is matched against
+the pattern `.qrCode(let productCode)` here.
+And like in the switch case,
+writing `let` extracts the associated value as a constant.
+
+<!-- XXX mention guards, and maybe for loops -->
+
 ## Raw Values
 
 The barcode example in <doc:Enumerations#Associated-Values>
@@ -519,6 +544,8 @@ and are set to some of the more common ASCII control characters.
 Raw values can be
 strings, characters, or any of the integer or floating-point number types.
 Each raw value must be unique within its enumeration declaration.
+
+<!-- XXX fix this note box abuse; this is important, not optional -->
 
 > Note: Raw values are *not* the same as associated values.
 > Raw values are set to prepopulated values

--- a/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/TSPL.docc/LanguageGuide/Enumerations.md
@@ -479,10 +479,12 @@ case let .qrCode(productCode):
   ```
 -->
 
-When you're matching just one case of an enumeration,
-you can use the shorter `if case` syntax
+When you're matching just one case of an enumeration ---
+for example,
+to extract its associated value ---
+there's a shorter syntax you can use
 instead of writing a full switch statement.
-For example:
+Here's what it looks like:
 
 ```swift
 if case .qrCode(let productCode) = productBarcode {
@@ -494,8 +496,10 @@ In this code,
 the condition for the `if` statement starts with `case`,
 indicating that the condition is a pattern instead of a Boolean value.
 If the pattern matches,
-the condition for the `if` is considered to be true;
-otherwise it's false.
+the condition for the `if` is considered to be true,
+and the code in the body of the `if` statement runs.
+The patterns you can write after `if case`
+are the same as the patterns you can write in a switch case.
 Just like in the switch statement earlier,
 the `productBarcode` variable is matched against
 the pattern `.qrCode(let productCode)` here.

--- a/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/TSPL.docc/LanguageGuide/Enumerations.md
@@ -549,16 +549,17 @@ Raw values can be
 strings, characters, or any of the integer or floating-point number types.
 Each raw value must be unique within its enumeration declaration.
 
-<!-- XXX fix this note box abuse; this is important, not optional -->
-
-> Note: Raw values are *not* the same as associated values.
-> Raw values are set to prepopulated values
-> when you first define the enumeration in your code,
-> like the three ASCII codes above.
-> The raw value for a particular enumeration case is always the same.
-> Associated values are set when you create a new constant or variable
-> based on one of the enumeration's cases,
-> and can be different each time you do so.
+Although you can use both raw values and associated values
+to give an enumeration an additional value,
+it's important to understand the difference between them.
+You pick the raw value for an enumeration case
+when you define that enumeration case in your code,
+like the three ASCII codes above.
+The raw value for a particular enumeration case is always the same.
+In contrast,
+you pick associated values when you create a new constant or variable
+using one of the enumeration's cases,
+and you can pick a different value each time you do so.
 
 ### Implicitly Assigned Raw Values
 

--- a/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/TSPL.docc/LanguageGuide/Enumerations.md
@@ -495,7 +495,7 @@ if case .qrCode(let productCode) = productBarcode {
 Just like in the switch statement earlier,
 the `productBarcode` variable is matched against
 the pattern `.qrCode(let productCode)` here.
-And like in the switch case,
+And as in the switch case,
 writing `let` extracts the associated value as a constant.
 For more information about `if`-`case` statements,
 see <doc:ControlFlow#Patterns>.
@@ -546,7 +546,7 @@ to give an enumeration an additional value,
 it's important to understand the difference between them.
 You pick the raw value for an enumeration case
 when you define that enumeration case in your code,
-like the three ASCII codes above.
+such as the three ASCII codes above.
 The raw value for a particular enumeration case is always the same.
 In contrast,
 you pick associated values when you create a new constant or variable

--- a/TSPL.docc/LanguageGuide/Enumerations.md
+++ b/TSPL.docc/LanguageGuide/Enumerations.md
@@ -482,7 +482,7 @@ case let .qrCode(productCode):
 When you're matching just one case of an enumeration ---
 for example,
 to extract its associated value ---
-there's a shorter syntax you can use
+you can use an `if`-`case` statement
 instead of writing a full switch statement.
 Here's what it looks like:
 
@@ -492,21 +492,13 @@ if case .qrCode(let productCode) = productBarcode {
 }
 ```
 
-In this code,
-the condition for the `if` statement starts with `case`,
-indicating that the condition is a pattern instead of a Boolean value.
-If the pattern matches,
-the condition for the `if` is considered to be true,
-and the code in the body of the `if` statement runs.
-The patterns you can write after `if case`
-are the same as the patterns you can write in a switch case.
 Just like in the switch statement earlier,
 the `productBarcode` variable is matched against
 the pattern `.qrCode(let productCode)` here.
 And like in the switch case,
 writing `let` extracts the associated value as a constant.
-
-<!-- XXX mention guards, and maybe for loops -->
+For more information about `if`-`case` statements,
+see <doc:ControlFlow#Patterns>.
 
 ## Raw Values
 


### PR DESCRIPTION
This syntax was previously shown only in the reference, under [Optional Patterns](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/patterns#Optional-Pattern).  I've added a new section to the Control Flow chapter to discuss this — pattern-matching against tuples because that's the only suitable data type available at this point in the book.  I've added forward and backward cross-references to the section about enumerations that have associated values, because this syntax is the way you extract that associated value.

Fixes: rdar://145579866