### PR TITLE
Clarify property observer behavior during initialization

### DIFF
--- a/TSPL.docc/LanguageGuide/Initialization.md
+++ b/TSPL.docc/LanguageGuide/Initialization.md
@@ -31,7 +31,7 @@ or by assigning a default property value as part of the property's definition.
 These actions are described in the following sections.
 
 > Note: When you assign a default value to a stored property,
-> or set its initial value within an initializer,
+> or set its value within an initializer,
 > the value of that property is set directly,
 > without calling any property observers.
 

--- a/TSPL.docc/LanguageGuide/Properties.md
+++ b/TSPL.docc/LanguageGuide/Properties.md
@@ -736,8 +736,8 @@ the new value that you assign replaces the one that was just set.
 > Note: The `willSet` and `didSet` observers of superclass properties
 > are called when a property is set in a subclass initializer,
 > after the superclass initializer has been called.
-> They aren't called while a class is setting its own properties,
-> before the superclass initializer has been called.
+> They aren't called while a class is setting its own properties
+> in the body of the initializer.
 >
 > For more information about initializer delegation,
 > see <doc:Initialization#Initializer-Delegation-for-Value-Types>


### PR DESCRIPTION
The Language Guide expects that property observers will be triggered during initialization in some circumstances, but they categorically aren't triggered. I ran into this while building some example code on property observers and, without being too much of a language lawyer, I'd like to suggest a minor clarification.

## After a superclass initializer has been called:

The current note on property observer behavior during initialization [1] reads:
> Note: The `willSet` and `didSet` observers of superclass properties
> are called when a property is set in a subclass initializer,
> after the superclass initializer has been called.
> They aren't called while a class is setting its own properties,
> before the superclass initializer has been called.

The first sentence on superclass behavior is true, but the final sentence on same-class behavior is misleading. Property observers are not triggered regardless of whether the superclass initializer has been called or not. However, a mutating function called from the initializer _does_ trigger property observers. Personally I think this is counterintuitive, the topic has been discussed in the Swift Forum [2] and would probably be a headache for the compiler and isn't going to change anyway (in order to preserve the semantics of existing code). But the fact remains that the superclass initializer is a red herring in the final sentence.

The proposed change helps to clarify without going too far into the detail:
> They aren't called while a class is setting its own properties
> in the body of the initializer.

## After the initial value has been set:

Currently the note on initialization [3] reads:
> Note: When you assign a default value to a stored property,
> or set its initial value within an initializer,
> the value of that property is set directly,
> without calling any property observers.

This is another variation of the above. It's technically true but, in fact, it doesn't matter whether you are setting the initial value or not: the property observers are never called in these circumstances. The values are always set directly when we are within the initializer body.

Dropping the word 'initial' is more accurate:
> Note: When you assign a default value to a stored property,
> or set its value within an initializer,
> the value of that property is set directly,
> without calling any property observers.

## References.

[1] Property observers: 
https://docs.swift.org/swift-book/documentation/the-swift-programming-language/properties#Property-Observers

[2] Swift Forum topic:
https://forums.swift.org/t/should-property-observers-fired-in-initializers/14024/1

[3] Setting initial values for stored properties:
https://docs.swift.org/swift-book/documentation/the-swift-programming-language/initialization/#Setting-Initial-Values-for-Stored-Properties

## Example.

Tested with Xcode 16.3, Swift 6.1.

```Swift
import Foundation

// MARK: - Ship

class Ship {
    var crewSize: Int {
        willSet { print("Ship: willSet crewSize to", newValue) }
        didSet { print("Ship: didSet crewSize to", crewSize) }
    }

    init(crewSize: Int) {
        self.crewSize = crewSize
    }
}

// MARK: - CargoShip

class CargoShip: Ship {
    var cargoCapacity: Int {
        willSet { print("CargoShip: willSet cargoCapacity to", newValue) }
        didSet { print("CargoShip: didSet cargoCapacity to", cargoCapacity) }
    }

    init(cargoCapacity: Int, crewSize: Int) {
        self.cargoCapacity = cargoCapacity
        super.init(crewSize: crewSize)

        // Instance is now fully initialized.

        // Change a property in the superclass, property observers are called
        // as expected.
        self.crewSize += 5

        // Change a property in the class after the superclass has been
        // initialized, property observers are not called (?)
        self.cargoCapacity += 20

        // But call a function that changes a property in the class, property
        // observers are called (??)
        doubleCargoCapacity()
    }

    func doubleCargoCapacity() {
        cargoCapacity *= 2
    }
}

let cargoShip = CargoShip(cargoCapacity: 10, crewSize: 5)

// Ship: willSet crewSize to 10
// Ship: didSet crewSize to 10
// CargoShip: willSet cargoCapacity to 60 (triggered by doubleCargoCapacity)
// CargoShip: didSet cargoCapacity to 60 (triggered by doubleCargoCapacity)
```
