### PR TITLE
Remove the mention of `~Sendable` from the concurrency chapter.

### DIFF
--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -1587,6 +1587,10 @@ See also this PR that adds Sendable conformance to FileDescriptor:
 https://github.com/apple/swift-system/pull/112
 -->
 
+You can also use an unavailable conformance
+to suppress implicit conformance to a protocol,
+as discussed in <doc:Protocols#Implicit-Conformance-to-a-Protocol>.
+
 <!--
   LEFTOVER OUTLINE BITS
 

--- a/TSPL.docc/LanguageGuide/Concurrency.md
+++ b/TSPL.docc/LanguageGuide/Concurrency.md
@@ -1568,12 +1568,15 @@ struct TemperatureReading {
 -->
 
 To explicitly mark a type as not being sendable,
-write `~Sendable` after the type:
+write an unavailable conformance to `Sendable`:
 
 ```swift
-struct FileDescriptor: ~Sendable {
+struct FileDescriptor {
     let rawValue: Int
 }
+
+@available(*, unavailable)
+extension FileDescriptor: Sendable {}
 ```
 
 <!--
@@ -1583,10 +1586,6 @@ https://github.com/apple/swift-system/blob/main/Sources/System/FileDescriptor.sw
 See also this PR that adds Sendable conformance to FileDescriptor:
 https://github.com/apple/swift-system/pull/112
 -->
-
-For more information about
-suppressing an implicit conformance to a protocol,
-see <doc:Protocols#Implicit-Conformance-to-a-Protocol>.
 
 <!--
   LEFTOVER OUTLINE BITS

--- a/TSPL.docc/LanguageGuide/Protocols.md
+++ b/TSPL.docc/LanguageGuide/Protocols.md
@@ -1480,7 +1480,7 @@ is with an extension that you mark as unavailable:
 
 ```swift
 @available(*, unavailable)
-extension FileDescriptor Sendable { }
+extension FileDescriptor: Sendable { }
 ```
 
 <!--


### PR DESCRIPTION
This syntax does not exist yet, and if you write `~Sendable`, you'll get a compiler error that a conformance to `Sendable` cannot be suppressed. It's a good idea but it is neither pitched nor implemented.