### PR TITLE
Fix list of macro roles that need "names:" argument

### DIFF
--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -99,6 +99,10 @@ indicates the macro's role:
 
 The peer and member macro roles require a `names:` argument,
 listing the names of the symbols that the macro generates.
+The accessor macro role requires a `names:` argument if the
+macro generates a `willSet` or `didSet` property observer. An
+accessor macro that generates property observers can't add
+other accessors, because observers only apply to stored properties.
 The extension macro role also requires a `names:` argument
 if the macro adds declarations inside the extension.
 When a macro declaration includes the `names:` argument,

--- a/TSPL.docc/ReferenceManual/Attributes.md
+++ b/TSPL.docc/ReferenceManual/Attributes.md
@@ -97,7 +97,7 @@ indicates the macro's role:
   on an extension, a type alias, or a type that's nested inside a function,
   or use an extension macro to add an extension that has a peer macro.
 
-The peer, member, and accessor macro roles require a `names:` argument,
+The peer and member macro roles require a `names:` argument,
 listing the names of the symbols that the macro generates.
 The extension macro role also requires a `names:` argument
 if the macro adds declarations inside the extension.


### PR DESCRIPTION
This PR fixes a documentation bug stating that the `names:` argument is required for `@attached` macros with the `accessor` role. In reality, this argument is not required for accessor macros.

Fixes: https://github.com/apple/swift-book/issues/374
